### PR TITLE
fix: scope element expression walk to dotted property containers only (OOM)

### DIFF
--- a/python/cpmf_uips_xaml/__version__.py
+++ b/python/cpmf_uips_xaml/__version__.py
@@ -1,5 +1,5 @@
 """Version information for cpmf_uips_xaml package."""
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 __author__ = "Christian Prior-Mamulyan"
 __description__ = "Standalone XAML workflow parser for automation projects"

--- a/python/cpmf_uips_xaml/stages/parsing/extractors.py
+++ b/python/cpmf_uips_xaml/stages/parsing/extractors.py
@@ -788,16 +788,20 @@ class ActivityExtractor:
             expressions.extend(extracted_expressions)
 
         # Child-element expression syntax: <VisualBasicValue ExpressionText="..." />
-        # ExpressionText contains the raw VB.NET/C# expression (no brackets), so add directly.
-        for descendant in element.iter():
-            tag = descendant.tag.split("}")[-1] if "}" in descendant.tag else descendant.tag
-            if tag in _EXPR_ELEMENT_TAGS:
-                expr_text = descendant.get("ExpressionText")
-                if expr_text:
-                    expressions.append(expr_text)
-                # Older serializations may embed the expression as element text
-                if descendant.text and descendant.text.strip():
-                    expressions.append(descendant.text.strip())
+        # Only descend into dotted property containers (e.g. Assign.To, InvokeMethod.Parameters)
+        # to avoid walking into child activities and causing quadratic expression accumulation.
+        for child in element:
+            child_tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+            if "." not in child_tag:
+                continue
+            for descendant in child.iter():
+                tag = descendant.tag.split("}")[-1] if "}" in descendant.tag else descendant.tag
+                if tag in _EXPR_ELEMENT_TAGS:
+                    expr_text = descendant.get("ExpressionText")
+                    if expr_text:
+                        expressions.append(expr_text)
+                    if descendant.text and descendant.text.strip():
+                        expressions.append(descendant.text.strip())
 
         return list(set(expressions))  # Remove duplicates
 


### PR DESCRIPTION
Fixes OOM crash introduced in 0.1.2.

`element.iter()` on container activities (Sequence, If, etc.) walked ALL descendant activities, causing quadratic expression accumulation — expressions from child activities collected by the parent, then again by each child.

Fix: only descend into direct children whose local tag contains a dot (e.g. `Assign.To`, `InvokeMethod.Parameters`). These are property containers, not child activities, and are the only valid nesting locations for `VisualBasicValue` elements.

- All 86 unit tests pass
- No change to observable behaviour for correct Syntax B XAML